### PR TITLE
Removed the mention of FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,3 @@ So be curious, get stuck in, and enjoy!
 &nbsp;&nbsp;&nbsp;[Python](python.md) - The worlds fastest growing server-side language
 
 &nbsp;&nbsp;&nbsp;[Git & GitHub](git.md) - The worlds most popular version control and social coding network
-
-
-## Important Resources
-
-- [FAQ's](FAQ.md)


### PR DESCRIPTION
There is no FAQ page, so this was a broken link.

Actually, is the contents of this file even in use for the website? If not, perhaps it'd make sense to just replace the contents here with a mention of the way these files are used to create the stream 0 site with Jekyll.
